### PR TITLE
Fix logic for service type and loadBalancerIP rendering

### DIFF
--- a/charts/shc/templates/service.yaml
+++ b/charts/shc/templates/service.yaml
@@ -20,9 +20,9 @@ metadata:
     service.kubernetes.io/load-balancer-type: "External"
     {{- end }}
 spec:
-  type: {{ ternary "ClusterIP" "LoadBalancer" .Values.service.ingress.enabled }}
-  
-  {{- if not .Values.service.ingress.enabled }}
+  type: {{ .Values.service.type }}
+
+  {{- if eq .Values.service.type "LoadBalancer" }}
   loadBalancerIP: {{ .Values.global.externalIP }}
   externalTrafficPolicy: Cluster
   {{- end }}

--- a/charts/shc/templates/service.yaml
+++ b/charts/shc/templates/service.yaml
@@ -20,9 +20,9 @@ metadata:
     service.kubernetes.io/load-balancer-type: "External"
     {{- end }}
 spec:
-  type: {{ ternary "ClusterIP" "LoadBalancer" (not .Values.service.ingress.enabled) }}
+  type: {{ ternary "ClusterIP" "LoadBalancer" .Values.service.ingress.enabled }}
   
-  {{- if .Values.service.ingress.enabled }}
+  {{- if not .Values.service.ingress.enabled }}
   loadBalancerIP: {{ .Values.global.externalIP }}
   externalTrafficPolicy: Cluster
   {{- end }}

--- a/charts/shc/templates/service.yaml
+++ b/charts/shc/templates/service.yaml
@@ -20,9 +20,9 @@ metadata:
     service.kubernetes.io/load-balancer-type: "External"
     {{- end }}
 spec:
-  type: {{ ternary "ClusterIP" "LoadBalancer" .Values.service.ingress.enabled }}
+  type: {{ ternary "ClusterIP" "LoadBalancer" (not .Values.service.ingress.enabled) }}
   
-  {{- if not .Values.service.ingress.enabled }}
+  {{- if .Values.service.ingress.enabled }}
   loadBalancerIP: {{ .Values.global.externalIP }}
   externalTrafficPolicy: Cluster
   {{- end }}


### PR DESCRIPTION
Reverse incorrect conditions for service.ingress.enabled. Ensures that service type and loadBalancerIP are appropriately configured based on the ingress setting, aligning with the expected configuration behavior.